### PR TITLE
[auto] Translate JAVA API Reference to Chinese

### DIFF
--- a/chinese/java/_index.md
+++ b/chinese/java/_index.md
@@ -1,0 +1,9 @@
+---
+title: Aspose.CAD 适用于 Java
+type: docs
+weight: 11
+url: /zh/java/
+keywords: 
+description: 
+is_root: true
+---


### PR DESCRIPTION
Automated translation of the JAVA API Reference to **Chinese** (`zh`) generated by RDA.

- Pages translated: 1/1
- Errors: 0
- Source: `english/java`
- Output: `chinese/java`

🤖 Generated by RDA